### PR TITLE
change script path from /opt/bin/python3 to /usr/bin/python3 to allow…

### DIFF
--- a/telegrafFritzBox.py
+++ b/telegrafFritzBox.py
@@ -1,4 +1,4 @@
-#!/opt/bin/python3
+#!/usr/bin/python3
 
 # This script is for exporting FritzBox metrics into Telegraf in InfluxDB format.
 # https://github.com/Schmidsfeld/TelegrafFritzBox


### PR DESCRIPTION
… running the script directly

telegraf@26ce82c980ca:/usr/local/bin$ ./telegrafFritzBox.py
Password required.

Options:
-i [ADDRESS],  IP-address of the FritzBox (Default 169.254.1.1)
-p [PASSWORD], Fritzbox authentication password
-u [USERNAME], Fritzbox authentication username (Default: Admin)
--port [PORT], Port of the FritzBox (Default: 49000)
-e [ENCRYPT],  use secure connection (Default: Off)

Hint: if this script is not working often IP or password is missing