### PR TITLE
autodect if the FritzBox is connected via DSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM telegraf:1.21.1
+FROM telegraf:1.22.4
 LABEL description="Based on telegraf, this image adds python3 and a telegraf input script to feed fritbox metrics into an influxdb"
 
 WORKDIR /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM telegraf:1.22.4
+FROM telegraf:1.21.1
 LABEL description="Based on telegraf, this image adds python3 and a telegraf input script to feed fritbox metrics into an influxdb"
 
 WORKDIR /usr/local/bin

--- a/telegrafFritzBox.py
+++ b/telegrafFritzBox.py
@@ -125,11 +125,14 @@ else:
 
 # Get FritzBox data so it isn't requested mutiple times
 deviceInfo = readfritz('DeviceInfo1', 'GetInfo')
+wanInfo = readfritz('WANCommonIFC1', 'GetCommonLinkProperties')
+connectionType = extractvar(wanInfo, 'NewWANAccessType', False, True)
+if connectionType == 'NewWANAccessType="DSL"':
+    IS_DSL = True
 if IS_DSL:
     connectionInfo = readfritz('WANPPPConnection1', 'GetInfo')
 else:
     connectionInfo = readfritz('WANIPConnection1', 'GetInfo')
-wanInfo = readfritz('WANCommonIFC1', 'GetCommonLinkProperties')
 trafficInfo = readfritz('WANCommonIFC1', 'GetAddonInfos')
 dslInfo = readfritz('WANDSLInterfaceConfig1', 'GetInfo')
 dslError = readfritz('WANDSLInterfaceConfig1', 'GetStatisticsTotal')
@@ -161,7 +164,6 @@ upTime = extractvar(deviceInfo, 'NewUpTime', True)
 connectionTime = extractvar(connectionInfo, 'NewUptime', True, False, 'ConnectionTime')
 connectionStatus = extractvar(connectionInfo, 'NewConnectionStatus', False)
 connectionError = extractvar(connectionInfo, 'NewLastConnectionError', False, True, 'LastError')
-connectionType = extractvar(wanInfo, 'NewWANAccessType', False, True)
 maxDownRate = extractvar(wanInfo, 'NewLayer1DownstreamMaxBitRate', True)
 maxUpRate = extractvar(wanInfo, 'NewLayer1UpstreamMaxBitRate', True)
 


### PR DESCRIPTION
use the information from wanInfo + connectionType to change IS_DSL to True if the Fritz!Box is connected via DSL. Successfully tested with an Fritz!Box 5760 running Fritz OS 7.29:

telegraf@52bbfd5309f9:/usr/local/bin$ python3 telegrafFritzBox.py -i $FRITZ_IP_ADDRESS -u $FRITZ_USERNAME -p $FRITZ_PASSWORD FritzBox,host=fritz-***,source=general ModelName="FRITZ!Box 7560",WANAccessType="DSL",SerialNumber="E8DF703AD84D",Firmware="7.29" FritzBox,host=fritz-***,source=status UpTime=353397i,ConnectionStatus="Connected",LastError="ERROR_NONE" FritzBox,host=fritz-***,source=wan ConnectionTime=247028i,Layer1DownstreamMaxBitRate=106646000i,Layer1UpstreamMaxBitRate=35871000i,ByteReceiveRate=2019i,ByteSendRate=1957i,PacketReceiveRate=0i,PacketSendRate=0i,TotalBytesReceived64=21742005632,TotalBytesSent64=31993873719 FritzBox,host=fritz-***,source=dsl DownstreamCurrRate=109998i,UpstreamCurrRate=36999i,DownstreamMaxRate=135086i,UpstreamMaxRate=45021i,DownstreamNoiseMargin=130i,UpstreamNoiseMargin=90i,DownstreamPower=498i,UpstreamPower=514i,DownstreamAttenuation=90i,UpstreamAttenuation=90i,HECErrors=0i,ATUCHECErrors=0i,CRCErrors=0i,ATUCCRCErrors=0i,FECErrors=0i,ATUCFECErrors=772i FritzBox,host=fritz-***,source=network ExternalIPAddress="*********",DNSServers="*********, *********, *********, *********",LocalDNSServer="*********",HostNumberOfEntries=47i,HostsKnown=47i,HostsKnownLAN=29i,HostsKnownWLAN=0i,HostsActive=27i,HostsActiveLAN=25i,HostsActiveWLAN=0i FritzBox,host=fritz-***,source=lan PacketsSent=8199220i,PacketsReceived=2576133i FritzBox,host=fritz-***,source=wlan_2.4GHz SSID="*********",Channel=13i,ClientsNumber=0i,PacketsSent=0i,PacketsReceived=0i FritzBox,host=fritz-***,source=wlan_5GHz SSID="*********",Channel=48i,ClientsNumber=0i,PacketsSent=0i,PacketsReceived=0i FritzBox,host=fritz-***,source=wlan_Guest SSID="*********",Channel=13i,ClientsNumber=0i,PacketsSent=0i,PacketsReceived=0i